### PR TITLE
Add more Curia case pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This repository automatically fetches Dutch-language court cases from the Court 
 
 ## 📌 What It Does
 
-- Crawls two official CURIA pages for legal case links:
+- Crawls four official CURIA pages for legal case links:
   - [C2 Jurisprudence](https://curia.europa.eu/en/content/juris/c2_juris.htm)
   - [T2 Jurisprudence](https://curia.europa.eu/en/content/juris/t2_juris.htm)
+  - [C1 Jurisprudence](https://curia.europa.eu/en/content/juris/c1_juris.htm)
+  - [F1 Jurisprudence](https://curia.europa.eu/en/content/juris/f1_juris.htm)
 - Extracts CELEX identifiers from those links
 - Fetches the full Dutch text from [EUR-Lex](https://eur-lex.europa.eu/)
 - Pushes new cases (URL, content, source) to the Hugging Face dataset: [`vGassen/CJEU-Curia-Dutch-Court-Cases`](https://huggingface.co/datasets/vGassen/CJEU-Curia-Dutch-Court-Cases)

--- a/update_cases.py
+++ b/update_cases.py
@@ -9,7 +9,9 @@ from huggingface_hub import login
 # Config
 CURIA_URLS = [
     "https://curia.europa.eu/en/content/juris/c2_juris.htm",
-    "https://curia.europa.eu/en/content/juris/t2_juris.htm"
+    "https://curia.europa.eu/en/content/juris/t2_juris.htm",
+    "https://curia.europa.eu/en/content/juris/c1_juris.htm",
+    "https://curia.europa.eu/en/content/juris/f1_juris.htm",
 ]
 EURLEX_TEMPLATE = "https://eur-lex.europa.eu/legal-content/NL/TXT/HTML/?uri=CELEX:{}"
 DATASET_NAME = "vGassen/CJEU-Curia-Dutch-Court-Cases"


### PR DESCRIPTION
## Summary
- add the C1 and F1 jurisprudence pages to the crawler
- document the new pages in README

## Testing
- `python -m py_compile update_cases.py`

------
https://chatgpt.com/codex/tasks/task_e_68449c421878832993bd824298ca8ae2