### PR TITLE
Improve page crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This repository automatically fetches Dutch-language court cases from the Court 
 
 ## 📌 What It Does
 
-- Crawls two official CURIA pages for legal case links:
+- Crawls four official CURIA pages for legal case links:
   - [C2 Jurisprudence](https://curia.europa.eu/en/content/juris/c2_juris.htm)
   - [T2 Jurisprudence](https://curia.europa.eu/en/content/juris/t2_juris.htm)
+  - [C1 Jurisprudence](https://curia.europa.eu/en/content/juris/c1_juris.htm)
+  - [F1 Jurisprudence](https://curia.europa.eu/en/content/juris/f1_juris.htm)
 - Extracts CELEX identifiers from those links
 - Fetches the full Dutch text from [EUR-Lex](https://eur-lex.europa.eu/)
 - Pushes new cases (URL, content, source) to the Hugging Face dataset: [`vGassen/CJEU-Curia-Dutch-Court-Cases`](https://huggingface.co/datasets/vGassen/CJEU-Curia-Dutch-Court-Cases)

--- a/update_cases.py
+++ b/update_cases.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import requests
+from urllib.parse import unquote, urlparse, parse_qs
 from bs4 import BeautifulSoup
 from datasets import load_dataset, Dataset
 from huggingface_hub import login
@@ -9,7 +10,9 @@ from huggingface_hub import login
 # Config
 CURIA_URLS = [
     "https://curia.europa.eu/en/content/juris/c2_juris.htm",
-    "https://curia.europa.eu/en/content/juris/t2_juris.htm"
+    "https://curia.europa.eu/en/content/juris/t2_juris.htm",
+    "https://curia.europa.eu/en/content/juris/c1_juris.htm",
+    "https://curia.europa.eu/en/content/juris/f1_juris.htm",
 ]
 EURLEX_TEMPLATE = "https://eur-lex.europa.eu/legal-content/NL/TXT/HTML/?uri=CELEX:{}"
 DATASET_NAME = "vGassen/CJEU-Curia-Dutch-Court-Cases"
@@ -21,6 +24,10 @@ if not HF_TOKEN:
     raise ValueError("HF_TOKEN environment variable not set.")
 login(HF_TOKEN)
 
+# use a session with a browser-like user agent to avoid basic bot blocks
+SESSION = requests.Session()
+SESSION.headers.update({"User-Agent": "Mozilla/5.0"})
+
 def get_existing_urls():
     try:
         dataset = load_dataset(DATASET_NAME, split="train")
@@ -29,29 +36,60 @@ def get_existing_urls():
         return set()
 
 def extract_celex_numbers(url):
-    response = requests.get(url)
+    response = SESSION.get(url)
     if not response.ok:
         return set()
     soup = BeautifulSoup(response.text, "html.parser")
     celex_numbers = set()
     for a in soup.find_all("a", href=True):
-        match = re.search(r"CELEX%3A([\dA-Z]+)", a["href"])
+        href = unquote(a["href"])
+        parsed = urlparse(href)
+        qs = parse_qs(parsed.query)
+        candidate = None
+        if "uri" in qs:
+            candidate = qs["uri"][0]
+        elif "CELEX" in qs:
+            candidate = qs["CELEX"][0]
+        if candidate:
+            match = re.search(r"CELEX[:=]?([\dA-Z]+)", candidate)
+            if match:
+                celex_numbers.add(match.group(1))
+                continue
+        match = re.search(r"CELEX[:=]?([\dA-Z]+)", href)
         if match:
             celex_numbers.add(match.group(1))
     return celex_numbers
 
 def fetch_case_content(celex):
-    url = EURLEX_TEMPLATE.format(celex)
-    response = requests.get(url)
+    en_url = f"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}"
+    response = SESSION.get(en_url)
+    nl_url = None
+    if response.ok:
+        soup = BeautifulSoup(response.text, "html.parser")
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "NL/TXT" in href and "CELEX" in href:
+                if href.startswith("//"):
+                    href = "https:" + href
+                elif href.startswith("/"):
+                    href = "https://eur-lex.europa.eu" + href
+                nl_url = href
+                break
+    if not nl_url:
+        nl_url = EURLEX_TEMPLATE.format(celex)
+
+    response = SESSION.get(nl_url)
     if not response.ok:
         return None, None
     soup = BeautifulSoup(response.text, "html.parser")
     content_div = soup.find("div", {"class": "tab-content"})
     if not content_div:
+        content_div = soup.find("div", {"id": "Texte-integral"})
+    if not content_div:
         return None, None
     paragraphs = content_div.find_all("p")
     text = "\n".join(p.get_text(strip=True) for p in paragraphs if p.get_text(strip=True))
-    return url, text
+    return nl_url, text
 
 def main():
     existing_urls = get_existing_urls()
@@ -60,10 +98,11 @@ def main():
     for curia_url in CURIA_URLS:
         celex_ids = extract_celex_numbers(curia_url)
         for celex in celex_ids:
-            url = EURLEX_TEMPLATE.format(celex)
-            if url in existing_urls:
-                continue
             final_url, content = fetch_case_content(celex)
+            if not final_url:
+                continue
+            if final_url in existing_urls:
+                continue
             if content:
                 new_entries.append({
                     "URL": final_url,


### PR DESCRIPTION
## Summary
- use a session with a browser user-agent
- robustly extract CELEX numbers from CURIA pages
- fetch the EN page first and follow the NL link

## Testing
- `python -m py_compile update_cases.py`


------
https://chatgpt.com/codex/tasks/task_e_68449c421878832993bd824298ca8ae2