### PR TITLE
Improve page crawling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This repository automatically fetches Dutch-language court cases from the Court 
 
 ## 📌 What It Does
 
-- Crawls two official CURIA pages for legal case links:
+- Crawls four official CURIA pages for legal case links:
   - [C2 Jurisprudence](https://curia.europa.eu/en/content/juris/c2_juris.htm)
   - [T2 Jurisprudence](https://curia.europa.eu/en/content/juris/t2_juris.htm)
+  - [C1 Jurisprudence](https://curia.europa.eu/en/content/juris/c1_juris.htm)
+  - [F1 Jurisprudence](https://curia.europa.eu/en/content/juris/f1_juris.htm)
 - Extracts CELEX identifiers from those links
 - Fetches the full Dutch text from [EUR-Lex](https://eur-lex.europa.eu/)
 - Pushes new cases (URL, content, source) to the Hugging Face dataset: [`vGassen/CJEU-Curia-Dutch-Court-Cases`](https://huggingface.co/datasets/vGassen/CJEU-Curia-Dutch-Court-Cases)

--- a/update_cases.py
+++ b/update_cases.py
@@ -1,7 +1,9 @@
 import os
 import re
+import logging
 import time
 import requests
+from urllib.parse import unquote, urlparse, parse_qs
 from bs4 import BeautifulSoup
 from datasets import load_dataset, Dataset
 from huggingface_hub import login
@@ -9,7 +11,9 @@ from huggingface_hub import login
 # Config
 CURIA_URLS = [
     "https://curia.europa.eu/en/content/juris/c2_juris.htm",
-    "https://curia.europa.eu/en/content/juris/t2_juris.htm"
+    "https://curia.europa.eu/en/content/juris/t2_juris.htm",
+    "https://curia.europa.eu/en/content/juris/c1_juris.htm",
+    "https://curia.europa.eu/en/content/juris/f1_juris.htm",
 ]
 EURLEX_TEMPLATE = "https://eur-lex.europa.eu/legal-content/NL/TXT/HTML/?uri=CELEX:{}"
 DATASET_NAME = "vGassen/CJEU-Curia-Dutch-Court-Cases"
@@ -21,6 +25,12 @@ if not HF_TOKEN:
     raise ValueError("HF_TOKEN environment variable not set.")
 login(HF_TOKEN)
 
+# use a session with a browser-like user agent to avoid basic bot blocks
+SESSION = requests.Session()
+SESSION.headers.update({"User-Agent": "Mozilla/5.0"})
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
 def get_existing_urls():
     try:
         dataset = load_dataset(DATASET_NAME, split="train")
@@ -29,51 +39,91 @@ def get_existing_urls():
         return set()
 
 def extract_celex_numbers(url):
-    response = requests.get(url)
+    logging.info(f"Fetching CURIA page: {url}")
+    response = SESSION.get(url)
     if not response.ok:
+        logging.warning(f"Failed to fetch {url} (status {response.status_code})")
         return set()
     soup = BeautifulSoup(response.text, "html.parser")
     celex_numbers = set()
     for a in soup.find_all("a", href=True):
-        match = re.search(r"CELEX%3A([\dA-Z]+)", a["href"])
+        href = unquote(a["href"])
+        parsed = urlparse(href)
+        qs = parse_qs(parsed.query)
+        candidate = None
+        if "uri" in qs:
+            candidate = qs["uri"][0]
+        elif "CELEX" in qs:
+            candidate = qs["CELEX"][0]
+        if candidate:
+            match = re.search(r"CELEX[:=]?([\dA-Z]+)", candidate, re.I)
+            if match:
+                celex_numbers.add(match.group(1))
+                continue
+        match = re.search(r"CELEX[:=]?([\dA-Z]+)", href, re.I)
         if match:
             celex_numbers.add(match.group(1))
+    logging.info(f"Found {len(celex_numbers)} CELEX numbers on {url}")
     return celex_numbers
 
 def fetch_case_content(celex):
-    url = EURLEX_TEMPLATE.format(celex)
-    response = requests.get(url)
+    en_url = f"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}"
+    logging.info(f"Resolving CELEX {celex}")
+    response = SESSION.get(en_url)
+    nl_url = None
+    if response.ok:
+        soup = BeautifulSoup(response.text, "html.parser")
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "NL/TXT" in href and "CELEX" in href:
+                if href.startswith("//"):
+                    href = "https:" + href
+                elif href.startswith("/"):
+                    href = "https://eur-lex.europa.eu" + href
+                nl_url = href
+                break
+    if not nl_url:
+        nl_url = EURLEX_TEMPLATE.format(celex)
+    logging.info(f"Fetching Dutch page: {nl_url}")
+
+    response = SESSION.get(nl_url)
     if not response.ok:
         return None, None
     soup = BeautifulSoup(response.text, "html.parser")
     content_div = soup.find("div", {"class": "tab-content"})
     if not content_div:
+        content_div = soup.find("div", {"id": "Texte-integral"})
+    if not content_div:
         return None, None
     paragraphs = content_div.find_all("p")
     text = "\n".join(p.get_text(strip=True) for p in paragraphs if p.get_text(strip=True))
-    return url, text
+    return nl_url, text
 
 def main():
     existing_urls = get_existing_urls()
     new_entries = []
+    logging.info(f"Loaded {len(existing_urls)} existing URLs")
 
     for curia_url in CURIA_URLS:
         celex_ids = extract_celex_numbers(curia_url)
         for celex in celex_ids:
-            url = EURLEX_TEMPLATE.format(celex)
-            if url in existing_urls:
-                continue
             final_url, content = fetch_case_content(celex)
+            if not final_url:
+                continue
+            if final_url in existing_urls:
+                logging.info(f"Skipping existing case {final_url}")
+                continue
             if content:
                 new_entries.append({
                     "URL": final_url,
                     "Content": content,
                     "Source": SOURCE
                 })
+                logging.info(f"Added case {final_url}")
                 time.sleep(1)
 
     if not new_entries:
-        print("No new cases found.")
+        logging.info("No new cases found.")
         return
 
     dataset = Dataset.from_dict({
@@ -93,7 +143,7 @@ def main():
         combined_dataset = dataset
 
     combined_dataset.push_to_hub(DATASET_NAME)
-    print(f"Pushed {len(new_entries)} new cases to {DATASET_NAME}.")
+    logging.info(f"Pushed {len(new_entries)} new cases to {DATASET_NAME}.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- use a session with a browser user-agent
- robustly extract CELEX numbers from CURIA pages
- fetch the EN page first and follow the NL link
- include C1 and F1 pages in the crawler
- add logging to show crawler progress

## Testing
- `python -m py_compile update_cases.py`


------
https://chatgpt.com/codex/tasks/task_e_68449c421878832993bd824298ca8ae2