### PR TITLE
Improve CELEX detection for javascript links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository automatically fetches Dutch-language court cases from the Court 
   - [T2 Jurisprudence](https://curia.europa.eu/en/content/juris/t2_juris.htm)
   - [C1 Jurisprudence](https://curia.europa.eu/en/content/juris/c1_juris.htm)
   - [F1 Jurisprudence](https://curia.europa.eu/en/content/juris/f1_juris.htm)
-- Extracts CELEX identifiers from those links
+- Extracts CELEX identifiers from those links. The crawler also handles `javascript:` links that use a `numdoc` parameter instead of a `CELEX` query string
 - Fetches the full Dutch text from [EUR-Lex](https://eur-lex.europa.eu/)
 - Pushes new cases (URL, content, source) to the Hugging Face dataset: [`vGassen/CJEU-Curia-Dutch-Court-Cases`](https://huggingface.co/datasets/vGassen/CJEU-Curia-Dutch-Court-Cases)
 - Runs every other day using GitHub Actions

--- a/update_cases.py
+++ b/update_cases.py
@@ -48,6 +48,10 @@ def extract_celex_numbers(url):
     celex_numbers = set()
     for a in soup.find_all("a", href=True):
         href = unquote(a["href"])
+        if href.startswith("javascript"):
+            inner = re.search(r"(https?://[^'\"]+)", href)
+            if inner:
+                href = inner.group(1)
         parsed = urlparse(href)
         qs = parse_qs(parsed.query)
         candidate = None
@@ -55,14 +59,16 @@ def extract_celex_numbers(url):
             candidate = qs["uri"][0]
         elif "CELEX" in qs:
             candidate = qs["CELEX"][0]
+        elif "numdoc" in qs:
+            candidate = qs["numdoc"][0]
         if candidate:
-            match = re.search(r"CELEX[:=]?([\dA-Z]+)", candidate, re.I)
+            match = re.search(r"6\d{4}[A-Z]{2}\d{4}", candidate)
             if match:
-                celex_numbers.add(match.group(1))
+                celex_numbers.add(match.group(0))
                 continue
-        match = re.search(r"CELEX[:=]?([\dA-Z]+)", href, re.I)
+        match = re.search(r"6\d{4}[A-Z]{2}\d{4}", href)
         if match:
-            celex_numbers.add(match.group(1))
+            celex_numbers.add(match.group(0))
     logging.info(f"Found {len(celex_numbers)} CELEX numbers on {url}")
     return celex_numbers
 


### PR DESCRIPTION
## Summary
- handle `javascript:` links that contain an inner URL
- extract CELEX IDs from `numdoc` parameters
- document new behavior in README

## Testing
- `python -m py_compile update_cases.py`

------
https://chatgpt.com/codex/tasks/task_e_684694da94e08329ba9d982ed8fda9ca