### PR TITLE
Use env token for Hugging Face login

### DIFF
--- a/CJEU_Scraper.py
+++ b/CJEU_Scraper.py
@@ -150,11 +150,23 @@ def main():
     # It will prompt for a token if not already logged in.
     # Ensure your token has 'write' permissions.
     print("\n[Step 1/5] Authenticating with Hugging Face Hub...")
+
+    # Prefer a token from the environment to avoid interactive prompts.
+    token = os.getenv("HF_TOKEN") or os.getenv("HUGGING_FACE_HUB_TOKEN")
+    if not token:
+        print(
+            "Could not find HF_TOKEN or HUGGING_FACE_HUB_TOKEN environment variable. "
+            "Set one of them to authenticate with Hugging Face Hub."
+        )
+        return
+
     try:
-        login()
+        login(token=token)
         print("Authentication successful.")
     except Exception as e:
-        print(f"Could not log in to Hugging Face Hub. Please ensure you have run `huggingface-cli login` or have set the HUGGING_FACE_HUB_TOKEN environment variable. Error: {e}")
+        print(
+            f"Could not log in to Hugging Face Hub. Please check your token. Error: {e}"
+        )
         return
 
     # 2. Load state

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ git clone https://github.com/your-username/your-repo-name.git
 cd your-repo-name
 ```
 
-2. **Set your HF_TOKEN and run the crawler**
+2. **Set your Hugging Face token and run the scraper**
+
+Set either the `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` environment variable before
+running the script:
 
 ```bash
 export HF_TOKEN=your_token
-python update_cases.py
+python CJEU_Scraper.py
 ```


### PR DESCRIPTION
## Summary
- use `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` for authentication
- update README instructions to reflect new token behaviour

## Testing
- `python -m py_compile CJEU_Scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6860416f9b608329a1723b7ae4b0ae70